### PR TITLE
Fix footer, hour timestamp is editable

### DIFF
--- a/client/src/components/Compile.jsx
+++ b/client/src/components/Compile.jsx
@@ -116,7 +116,7 @@ class Compile extends React.Component {
           </div>
         </div>
       </div>
-      <div className="container footer slideUp">
+      <div className="footer slideUp">
           <InputBox tab={this.state.tab}/>
           <Audio />
       </div>

--- a/client/src/components/Compile.jsx
+++ b/client/src/components/Compile.jsx
@@ -117,12 +117,8 @@ class Compile extends React.Component {
         </div>
       </div>
       <div className="container footer slideUp">
-        <div className="col-md-6">
           <InputBox tab={this.state.tab}/>
-        </div>
-        <div className="col-md-6">
           <Audio />
-        </div>
       </div>
     </div>
     ) : (<div></div>)

--- a/client/src/components/sub/Audio.jsx
+++ b/client/src/components/sub/Audio.jsx
@@ -16,7 +16,7 @@ class Audio extends React.Component {
       waveformDisplay: 'hidden',
       loadingDisplay: 'block',
       loadVal: 0,
-      clicked: false
+      clicked: false,
     };
     this.handleClick = this.handleClick.bind(this);
   }
@@ -104,40 +104,39 @@ class Audio extends React.Component {
       normalize: true
     };
     return (
-      <div className="row">
-        <div style={{display: this.state.loadingDisplay}}>
-            LOADING AUDIO FILE {this.state.loadVal}
+      <span style={{ display: 'flex', flex: 1, alignItems: 'center', justifyContent: 'center'}}>
+        <div style={{ display: this.state.loadingDisplay, position: 'absolute' }}>
+          LOADING AUDIO FILE {this.state.loadVal}
         </div>
-        <div className="col-md-1">
+        <span className="audioPlayer" style={{visibility: this.state.waveformDisplay}}>
           <i onClick={this.handleTogglePlay.bind(this)} className={`fa ${this.props.waveform.playing ? 'fa-pause-circle' : 'fa-play-circle'} fa-3x text-primary playButton`}></i>
-        </div>
-        <div className="col-md-10" ref="wavesurfContainer" onClick={this.handleClick.bind(this)} style={{visibility: this.state.waveformDisplay}}>
-          <Wavesurfer
-            volume={this.props.waveform.volume}
-            pos={this.props.waveform.pos}
-            options={waveOptions}
-            onPosChange={this.handlePosChange.bind(this)}
-            audioFile={this.props.room.roomInfo.audioUrl}
-            playing={this.props.waveform.playing}
-            onReady={this.handleReady.bind(this)}
-            onLoading={this.handleLoading.bind(this)}
-            onFinish={this.onFinish.bind(this)}
+          <span className="waveform" ref="wavesurfContainer" onClick={this.handleClick.bind(this)} >
+            <Wavesurfer
+              volume={this.props.waveform.volume}
+              pos={this.props.waveform.pos}
+              options={waveOptions}
+              onPosChange={this.handlePosChange.bind(this)}
+              audioFile={this.props.room.roomInfo.audioUrl}
+              playing={this.props.waveform.playing}
+              onReady={this.handleReady.bind(this)}
+              onLoading={this.handleLoading.bind(this)}
+              onFinish={this.onFinish.bind(this)}
+              isLoaded={this.state.shouldBeLoaded}
+            />
+          </span>
+          <input
+            name="simple-volume"
+            type="range"
+            min={0}
+            max={1}
+            step="0.01"
+            value={this.props.waveform.volume}
+            onChange={this.handleVolumeChange.bind(this)}
+            className="form-control"
+            orient="vertical"
           />
-        </div>
-        <div className="col-md-1">
-        <input
-          name="simple-volume"
-          type="range"
-          min={0}
-          max={1}
-          step="0.01"
-          value={this.props.waveform.volume}
-          onChange={this.handleVolumeChange.bind(this)}
-          className="form-control"
-          orient="vertical"
-        />
-        </div>
-      </div>
+        </span>
+      </span>
   );
   }
 }

--- a/client/src/components/sub/InputBox.jsx
+++ b/client/src/components/sub/InputBox.jsx
@@ -10,15 +10,15 @@ class InputBox extends React.Component {
     super(props);
     this.state = {
       timestamp: 0,
-      displayTimestamp: 'none',
+      stopTimestamp: false,
     };
   }
 
   keyUpHandler(e) {
-    if (e.target.value.trim() !== '' && this.state.displayTimestamp === 'none') {
-      this.setState({displayTimestamp: 'inline', timestamp: this.props.waveform.pos });
-    } else if (e.target.value.trim() === '' && this.state.displayTimestamp === 'inline') {
-      this.setState({displayTimestamp: 'none'});
+    if (e.target.value.trim() !== '' && !this.state.stopTimestamp) {
+      this.setState({ stopTimestamp: true, timestamp: this.props.waveform.pos });
+    } else if (e.target.value.trim() === '' && this.state.stopTimestamp) {
+      this.setState({ stopTimestamp: false });
     }
 
     if (e.keyCode === 13) {
@@ -46,7 +46,7 @@ class InputBox extends React.Component {
           console.log(savedNote);
           this.props.dispatch(addNote(savedNote));
           this.refs.inputNote.value = '';
-          this.setState({displayTimestamp: 'none'});
+          this.setState({ stopTimestamp: false });
         },
         error: console.log.bind(this)
       });
@@ -76,7 +76,7 @@ class InputBox extends React.Component {
     if (getCurrentView(this.props.routing.locationBeforeTransitions.pathname) === 'compile') {
       return <span className="lectureForm" >
         <input ref="inputNote" className="lectureInput" type="text" onKeyUp={this.keyUpHandler.bind(this)} autoFocus/>
-        <span style={{display: this.state.displayTimestamp}}>{this.formatTime(this.state.timestamp)}</span>
+        <span>{this.formatTime(this.state.stopTimestamp ? this.state.timestamp : this.props.waveform.pos)}</span>
       </span>;
     } 
       
@@ -90,8 +90,8 @@ const mapStateToProps = (state) => {
   return {
     ...state,
     NoteReducer,
-    RoomReducer
-  }
+    RoomReducer,
+  };
 };
 
 export default connect(mapStateToProps)(InputBox);

--- a/client/src/components/sub/Note.jsx
+++ b/client/src/components/sub/Note.jsx
@@ -66,7 +66,10 @@ class Note extends React.Component {
 
   editTimestampHandler(e) {
     e.preventDefault();
-    const newTimestamp = (+this.refs.editHour.value * 3600 + +this.refs.editMin.value * 60 + +this.refs.editSec.value) * 1000;
+    let newTimestamp = (+this.refs.editMin.value * 60 + +this.refs.editSec.value) * 1000;
+    if (this.refs.editHour) {
+      newTimestamp += this.refs.editHour.value * 3600;
+    }
     if (newTimestamp <= +this.props.room.roomInfo.timeLength) {
       this.props.dispatch(editTimestamp(this.props.noteInfo.id, newTimestamp));
     }

--- a/client/src/components/sub/Note.jsx
+++ b/client/src/components/sub/Note.jsx
@@ -94,14 +94,27 @@ class Note extends React.Component {
     if (this.props.view === 'compile') {
       const classColor = (i) => 'participant' + i;
       view = (
-        <div className={noteClass()}>
-          <input type="checkbox" ref="checkbox" onChange={this.toggleNoteHandler.bind(this)} checked={this.props.noteInfo.show}/>
-          {this.state.editContent ?
-            <span className="content">
-              <form onSubmit={this.editContentHandler.bind(this)}>
-                <input ref="noteInput" type="text" defaultValue={this.props.noteInfo.content} />
-              </form>
-            </span>
+          <div className={noteClass()}>
+            <input type="checkbox" ref="checkbox" onChange={this.toggleNoteHandler.bind(this)} checked={this.props.noteInfo.show}/>
+            {this.state.editContent ?
+              <span className="content">
+                <form onSubmit={this.editContentHandler.bind(this)}>
+                  <input ref="noteInput" type="text" defaultValue={this.props.noteInfo.content} />
+                </form>
+              </span>
+              :
+              <span className="content" onClick={this.contentClickHandler.bind(this)}>{this.props.noteInfo.content}</span>
+            }
+            {this.state.editTimestamp ? 
+              <span className="audioTimestamp">
+                <form onSubmit={this.editTimestampHandler.bind(this)}>
+                  <button className="btn btn-success btn-xs">Save</button>
+                  {this.props.noteInfo.audioTimestamp >= 3600000 && <input ref="editMin" type="number" min={0} defaultValue={ ~~(this.props.noteInfo.audioTimestamp / 3600000) } />}
+                  {this.props.noteInfo.audioTimestamp >= 3600000 ? ':' : ''}
+                  <input ref="editMin" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 60000) % 60} />:
+                  <input ref="editSec" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 1000) % 60} />
+                </form>
+              </span>
             :
             <span className={`content ${classColor(`${this.props.colorClass}`)}`} onClick={this.contentClickHandler.bind(this)}>{this.props.noteInfo.content}</span>
           }

--- a/client/src/components/sub/Note.jsx
+++ b/client/src/components/sub/Note.jsx
@@ -66,7 +66,7 @@ class Note extends React.Component {
 
   editTimestampHandler(e) {
     e.preventDefault();
-    const newTimestamp = (+this.refs.editMin.value * 60 + +this.refs.editSec.value) * 1000;
+    const newTimestamp = (+this.refs.editHour.value * 3600 + +this.refs.editMin.value * 60 + +this.refs.editSec.value) * 1000;
     if (newTimestamp <= +this.props.room.roomInfo.timeLength) {
       this.props.dispatch(editTimestamp(this.props.noteInfo.id, newTimestamp));
     }
@@ -109,7 +109,8 @@ class Note extends React.Component {
               <span className="audioTimestamp">
                 <form onSubmit={this.editTimestampHandler.bind(this)}>
                   <button className="btn btn-success btn-xs">Save</button>
-                  {this.props.room.roomInfo.timeLength >= 3600000 && <input ref="editHour" type="number" min={0} defaultValue={ ~~(this.props.noteInfo.audioTimestamp / 3600000) } />{':'}}
+                  {this.props.room.roomInfo.timeLength >= 3600000 && <input ref="editHour" type="number" min={0} defaultValue={ ~~(this.props.noteInfo.audioTimestamp / 3600000) } />}
+                  {this.props.room.roomInfo.timeLength >= 3600000 && ':'}
                   <input ref="editMin" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 60000) % 60} />:
                   <input ref="editSec" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 1000) % 60} />
                 </form>

--- a/client/src/components/sub/Note.jsx
+++ b/client/src/components/sub/Note.jsx
@@ -103,9 +103,9 @@ class Note extends React.Component {
                 </form>
               </span>
               :
-              <span className="content" onClick={this.contentClickHandler.bind(this)}>{this.props.noteInfo.content}</span>
+              <span className={`content ${classColor(`${this.props.colorClass}`)}`} onClick={this.contentClickHandler.bind(this)}>{this.props.noteInfo.content}</span>
             }
-            {this.state.editTimestamp ? 
+            {this.state.editTimestamp ?
               <span className="audioTimestamp">
                 <form onSubmit={this.editTimestampHandler.bind(this)}>
                   <button className="btn btn-success btn-xs">Save</button>
@@ -116,21 +116,10 @@ class Note extends React.Component {
                 </form>
               </span>
             :
-            <span className={`content ${classColor(`${this.props.colorClass}`)}`} onClick={this.contentClickHandler.bind(this)}>{this.props.noteInfo.content}</span>
-          }
-          {this.state.editTimestamp ?
-            <span className="audioTimestamp">
-              <form onSubmit={this.editTimestampHandler.bind(this)}>
-                <button className="btn btn-success btn-xs">Save</button>
-                <input ref="editMin" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 60000) % 60} />:
-                <input ref="editSec" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 1000) % 60} />
-              </form>
-            </span>
-          :
-            <span className="audioTimestamp" onClick={this.timestampClickHandler.bind(this)}>
-              {this.formatTime(this.props.noteInfo.audioTimestamp)}
-            </span>
-          }
+              <span className="audioTimestamp" onClick={this.timestampClickHandler.bind(this)}>
+                {this.formatTime(this.props.noteInfo.audioTimestamp)}
+              </span>
+            }
           <span className="deleteNoteButton" onClick={this.deleteHandler.bind(this)}><i className="ion ion-close-round deleteNoteIcon"></i></span>
         </div>
       );

--- a/client/src/components/sub/Note.jsx
+++ b/client/src/components/sub/Note.jsx
@@ -109,8 +109,7 @@ class Note extends React.Component {
               <span className="audioTimestamp">
                 <form onSubmit={this.editTimestampHandler.bind(this)}>
                   <button className="btn btn-success btn-xs">Save</button>
-                  {this.props.noteInfo.audioTimestamp >= 3600000 && <input ref="editMin" type="number" min={0} defaultValue={ ~~(this.props.noteInfo.audioTimestamp / 3600000) } />}
-                  {this.props.noteInfo.audioTimestamp >= 3600000 ? ':' : ''}
+                  {this.props.room.roomInfo.timeLength >= 3600000 && <input ref="editHour" type="number" min={0} defaultValue={ ~~(this.props.noteInfo.audioTimestamp / 3600000) } />{':'}}
                   <input ref="editMin" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 60000) % 60} />:
                   <input ref="editSec" type="number" min={0} max={59} defaultValue={~~(this.props.noteInfo.audioTimestamp / 1000) % 60} />
                 </form>

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -7,7 +7,7 @@
 */
 
 body {
-  padding-bottom: 50px;
+  padding-bottom: 90px;
 }
 
 .container-fluid {
@@ -419,6 +419,11 @@ input[type=checkbox] {
   width: 100%;
   align-items: center;
   bottom: 0px;
+  flex-wrap: wrap;
+}
+
+.footer > * {
+  min-width: 320px;
 }
 
 .lectureForm > * {

--- a/client/styles/style.css
+++ b/client/styles/style.css
@@ -397,11 +397,11 @@ input[type=checkbox] {
   =================================
 */
 
-.slideUp {
+/*.slideUp {
   animation: slideUp 0.3s ease 0.6s forwards;
   -moz-animation: slideUp 0.3s ease 0.6s forwards;
   -webkit-animation: slideUp 0.3s ease 0.6s forwards;
-}
+}*/
 
 @keyframes slideUp {
   0% {
@@ -418,16 +418,20 @@ input[type=checkbox] {
   position: fixed;
   width: 100%;
   align-items: center;
-  bottom: -50px;
-  height: 50px;
+  bottom: 0px;
 }
 
-.footer > * > * {
+.lectureForm > * {
   margin: 0 12px;
 }
 
 .audioPlayer {
-  display: inline-block;
+  display: flex;
+  flex: 1;
+}
+
+.audioPlayer > * {
+  margin: 0 12px;
 }
 
 .waveform {


### PR DESCRIPTION
- Revert footer back to display: flex
- Fix floating play button when the window width was small
- Input box stacks on audio when the window is small
- Timestamp will always be shown when notes are being taken on compile page
- Hours are now editable for notes in compile view